### PR TITLE
chore: migrate install/update channel to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,23 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Validate tag format
+        id: release_meta
         run: |
           TAG_NAME="${GITHUB_REF_NAME}"
-          if [[ ! "${TAG_NAME}" =~ ^v[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}$ ]]; then
+          if [[ ! "${TAG_NAME}" =~ ^v([0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2})(-rc\.[0-9]+)?$ ]]; then
             echo "Invalid release tag format: ${TAG_NAME}"
+            echo "Expected stable: vYYYY.M.D or prerelease: vYYYY.M.D-rc.N"
             exit 1
           fi
+
+          BASE_VERSION="${BASH_REMATCH[1]}"
+          SUFFIX="${BASH_REMATCH[2]}"
+          if [[ -n "${SUFFIX}" ]]; then
+            echo "prerelease=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "prerelease=false" >> "${GITHUB_OUTPUT}"
+          fi
+          echo "base_version=${BASE_VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: Install dependencies
         run: |
@@ -47,7 +58,7 @@ jobs:
 
       - name: Validate tag and project versions
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${{ steps.release_meta.outputs.base_version }}"
           PYPROJECT_VERSION=$(python - <<'PY'
           import tomllib
           from pathlib import Path
@@ -96,6 +107,7 @@ jobs:
       - name: Publish GitHub release assets
         uses: softprops/action-gh-release@v2
         with:
+          prerelease: ${{ steps.release_meta.outputs.prerelease }}
           files: |
             dist/*.whl
             dist/*.tar.gz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@ CLI commands commonly exercised during update work:
 - `uv run modelmeter update check --json`
 - `uv run modelmeter update apply --dry-run`
 
+Release distribution and update checks:
+- Installer script is hosted on GitHub raw (`https://raw.githubusercontent.com/ntbsx/modelmeter/main/scripts/install.sh`)
+- Default update metadata endpoint is GitHub Releases API (`https://api.github.com/repos/ntbsx/modelmeter/releases/latest`)
+
 Frontend scripts:
 - `npm run --prefix web dev`
 - `npm run --prefix web build`

--- a/README.md
+++ b/README.md
@@ -4,30 +4,30 @@ ModelMeter: OpenCode usage analytics for terminal and web.
 
 ## Installation
 
-ModelMeter is currently distributed via GitLab releases (not PyPI yet).
+ModelMeter is currently distributed via GitHub Releases (not PyPI yet).
 
-Install via the GitLab release installer script (public project):
+Install via the GitHub release installer script (public project):
 
 ```bash
 # Latest release
-curl -fsSL https://gitlab.com/ntbsdev/modelmeter/-/raw/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/ntbsx/modelmeter/main/scripts/install.sh | bash
 
 # Pinned release
-curl -fsSL https://gitlab.com/ntbsdev/modelmeter/-/raw/main/scripts/install.sh | bash -s -- --version 2026.3.16
+curl -fsSL https://raw.githubusercontent.com/ntbsx/modelmeter/main/scripts/install.sh | bash -s -- --version 2026.3.16
 ```
 
 Choose installation method explicitly if needed:
 
 ```bash
 # Prefer pipx
-curl -fsSL https://gitlab.com/ntbsdev/modelmeter/-/raw/main/scripts/install.sh | bash -s -- --method pipx
+curl -fsSL https://raw.githubusercontent.com/ntbsx/modelmeter/main/scripts/install.sh | bash -s -- --method pipx
 
 # Use pip --user
-curl -fsSL https://gitlab.com/ntbsdev/modelmeter/-/raw/main/scripts/install.sh | bash -s -- --method pip
+curl -fsSL https://raw.githubusercontent.com/ntbsx/modelmeter/main/scripts/install.sh | bash -s -- --method pip
 ```
 
 The installed package includes the built web UI, so `modelmeter serve` works without cloning the repo.
-The installer prefers wheel assets published on the GitLab release page and falls back to source archives.
+The installer prefers wheel assets published on the GitHub release page and falls back to source archives.
 
 ## Quick Start
 
@@ -78,7 +78,7 @@ API behavior for auth-enabled mode:
 
 ## Self-Update
 
-ModelMeter can check for newer GitLab releases and prepare an install command:
+ModelMeter can check for newer GitHub releases and prepare an install command:
 
 ```bash
 # Check latest release vs current local version
@@ -98,7 +98,7 @@ Update behavior can be configured with environment variables:
 
 ```bash
 export MODELMETER_UPDATE_CHECK_ENABLED=true
-export MODELMETER_UPDATE_CHECK_URL="https://gitlab.com/api/v4/projects/ntbsdev%2Fmodelmeter/releases/permalink/latest"
+export MODELMETER_UPDATE_CHECK_URL="https://api.github.com/repos/ntbsx/modelmeter/releases/latest"
 export MODELMETER_UPDATE_CHECK_TIMEOUT_SECONDS=8
 ```
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -61,7 +61,7 @@ git push --tags
 Run install from release metadata:
 
 ```bash
-curl -fsSL https://gitlab.com/ntbsdev/modelmeter/-/raw/main/scripts/install.sh | bash -s -- --version <YYYY.M.D>
+curl -fsSL https://raw.githubusercontent.com/ntbsx/modelmeter/main/scripts/install.sh | bash -s -- --version <YYYY.M.D>
 modelmeter --version
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PROJECT_PATH="ntbsdev/modelmeter"
-PROJECT_PATH_ENCODED="ntbsdev%2Fmodelmeter"
-GITLAB_API="https://gitlab.com/api/v4/projects/${PROJECT_PATH_ENCODED}"
+PROJECT_PATH="ntbsx/modelmeter"
+GITHUB_API="https://api.github.com/repos/${PROJECT_PATH}"
 
 VERSION=""
 METHOD="auto"
 
 usage() {
   cat <<'EOF'
-Install ModelMeter from GitLab releases.
+Install ModelMeter from GitHub releases.
 
 Usage:
   install.sh [--version X.Y.Z] [--method auto|pipx|pip]
@@ -58,7 +57,7 @@ if ! command -v curl >/dev/null 2>&1; then
 fi
 
 resolve_latest_version() {
-  curl -fsSL "${GITLAB_API}/releases/permalink/latest" | python3 -c '
+  curl -fsSL "${GITHUB_API}/releases/latest" | python3 -c '
 import json, sys
 release = json.load(sys.stdin)
 tag = str(release.get("tag_name", "")).strip()
@@ -70,16 +69,15 @@ print(tag.lstrip("v"))
 
 resolve_wheel_url() {
   local tag="$1"
-  curl -fsSL "${GITLAB_API}/releases/${tag}" | python3 -c '
+  curl -fsSL "${GITHUB_API}/releases/tags/${tag}" | python3 -c '
 import json
 import sys
 
 release = json.load(sys.stdin)
-assets = release.get("assets", {})
-links = assets.get("links", [])
+assets = release.get("assets", [])
 
-for link in links:
-    url = str(link.get("url", "")).strip()
+for asset in assets:
+    url = str(asset.get("browser_download_url", "")).strip()
     if url.endswith(".whl"):
         print(url)
         raise SystemExit(0)
@@ -93,7 +91,7 @@ if [[ -z "$VERSION" ]]; then
 fi
 
 TAG="v${VERSION}"
-ARCHIVE_URL="https://gitlab.com/${PROJECT_PATH}/-/archive/${TAG}/modelmeter-${TAG}.tar.gz"
+ARCHIVE_URL="https://github.com/${PROJECT_PATH}/archive/refs/tags/${TAG}.tar.gz"
 WHEEL_URL=""
 
 if WHEEL_URL="$(resolve_wheel_url "${TAG}" 2>/dev/null)"; then

--- a/src/modelmeter/config/settings.py
+++ b/src/modelmeter/config/settings.py
@@ -24,9 +24,7 @@ class AppSettings(BaseSettings):
     pricing_remote_timeout_seconds: int = Field(default=8, ge=1, le=60)
     pricing_cache_ttl_hours: int = Field(default=24, ge=1, le=168)
     update_check_enabled: bool = True
-    update_check_url: str = (
-        "https://gitlab.com/api/v4/projects/ntbsdev%2Fmodelmeter/releases/permalink/latest"
-    )
+    update_check_url: str = "https://api.github.com/repos/ntbsx/modelmeter/releases/latest"
     update_check_timeout_seconds: int = Field(default=8, ge=1, le=60)
 
     @property

--- a/src/modelmeter/core/updater.py
+++ b/src/modelmeter/core/updater.py
@@ -13,9 +13,9 @@ from modelmeter.common.version import get_base_version
 from modelmeter.config.settings import AppSettings
 from modelmeter.core.models import UpdateCheckResponse
 
-PROJECT_PATH = "ntbsdev/modelmeter"
-PROJECT_PATH_ENCODED = "ntbsdev%2Fmodelmeter"
-GITLAB_API = f"https://gitlab.com/api/v4/projects/{PROJECT_PATH_ENCODED}"
+PROJECT_PATH = "ntbsx/modelmeter"
+GITHUB_API = f"https://api.github.com/repos/{PROJECT_PATH}"
+GITHUB_WEB = f"https://github.com/{PROJECT_PATH}"
 
 
 def _calver_key(value: str) -> tuple[int, int, int]:
@@ -59,7 +59,7 @@ def _resolve_latest_release(
 
     tag = tag_name.strip()
     version = tag.lstrip("v")
-    web_url = payload.get("_links", {}).get("self")
+    web_url = payload.get("html_url")
     if not isinstance(web_url, str):
         web_url = payload.get("url") if isinstance(payload.get("url"), str) else None
     return version, tag, web_url, None
@@ -97,23 +97,19 @@ def check_for_updates(*, settings: AppSettings) -> UpdateCheckResponse:
 
 def _resolve_wheel_url(*, tag: str, timeout_seconds: int) -> str | None:
     payload = _fetch_json(
-        f"{GITLAB_API}/releases/{tag}",
+        f"{GITHUB_API}/releases/tags/{tag}",
         timeout_seconds=timeout_seconds,
     )
     assets_obj = payload.get("assets")
-    if not isinstance(assets_obj, dict):
+    if not isinstance(assets_obj, list):
         return None
-    assets = cast(dict[str, Any], assets_obj)
-    links_obj = assets.get("links")
-    if not isinstance(links_obj, list):
-        return None
-    links = cast(list[Any], links_obj)
 
-    for link_obj in links:
-        if not isinstance(link_obj, dict):
+    assets = cast(list[Any], assets_obj)
+    for asset_obj in assets:
+        if not isinstance(asset_obj, dict):
             continue
-        link = cast(dict[str, Any], link_obj)
-        url = link.get("url")
+        asset = cast(dict[str, Any], asset_obj)
+        url = asset.get("browser_download_url")
         if isinstance(url, str) and url.endswith(".whl"):
             return url
     return None
@@ -124,7 +120,7 @@ def _resolve_install_spec(*, version: str, timeout_seconds: int) -> str:
     wheel_url = _resolve_wheel_url(tag=tag, timeout_seconds=timeout_seconds)
     if wheel_url is not None:
         return wheel_url
-    return f"https://gitlab.com/{PROJECT_PATH}/-/archive/{tag}/modelmeter-{tag}.tar.gz"
+    return f"{GITHUB_WEB}/archive/refs/tags/{tag}.tar.gz"
 
 
 def _run_install_command(command: list[str]) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -215,7 +215,7 @@ def test_update_check_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
             latest_version="2026.3.20",
             update_available=True,
             release_tag="v2026.3.20",
-            release_url="https://gitlab.example/release",
+            release_url="https://github.com/ntbsx/modelmeter/releases/tag/v2026.3.20",
             checked_at_ms=1,
         )
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,4 +11,6 @@ def test_default_opencode_data_dir() -> None:
 def test_update_check_is_enabled_by_default() -> None:
     settings = AppSettings()
     assert settings.update_check_enabled is True
-    assert "gitlab.com/api/v4/projects" in settings.update_check_url
+    assert (
+        settings.update_check_url == "https://api.github.com/repos/ntbsx/modelmeter/releases/latest"
+    )

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -12,7 +12,12 @@ def test_check_for_updates_reports_available(monkeypatch: pytest.MonkeyPatch) ->
         *, settings: AppSettings
     ) -> tuple[str | None, str | None, str | None, str | None]:
         _ = settings
-        return "2026.3.20", "v2026.3.20", "https://gitlab.example/release", None
+        return (
+            "2026.3.20",
+            "v2026.3.20",
+            "https://github.com/ntbsx/modelmeter/releases/tag/v2026.3.20",
+            None,
+        )
 
     monkeypatch.setattr(updater_module, "get_base_version", lambda: "2026.3.1")
     monkeypatch.setattr(updater_module, "_resolve_latest_release", _mock_latest_release)


### PR DESCRIPTION
## Summary
- switch installer and updater release metadata resolution from GitLab to GitHub Releases APIs
- update default update-check endpoint, install docs, and release runbook links to GitHub-hosted install/update sources
- add prerelease workflow support for tags like `vYYYY.M.D-rc.N` while preserving stable release validation against canonical version

## Verification
- uv run pytest tests/test_settings.py tests/test_updater.py tests/test_api.py tests/test_cli.py
- make release-check