### PR TITLE
chore: opt GitHub workflows into Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   version_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` for CI and release workflows
- proactively opt JavaScript-based GitHub Actions into Node 24 ahead of Node 20 deprecation
- keep existing workflow action versions and behavior unchanged

## Verification
- workflow YAML changes only